### PR TITLE
Create item template and AssetUtil wrappers

### DIFF
--- a/PrestigeItems/Items/0_ItemTemplate.cs
+++ b/PrestigeItems/Items/0_ItemTemplate.cs
@@ -1,0 +1,77 @@
+﻿using PrestigeItems.Util;
+using R2API;
+using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace PrestigeItems.Items
+{
+    internal class ItemTemplate
+    {
+        public static ItemDef itemDef;
+        private static String itemId = "";
+
+        internal static void Init()
+        {
+            GenerateItem();
+            AddTokens();
+
+            var displayRules = new ItemDisplayRuleDict(null);
+            ItemAPI.Add(new CustomItem(itemDef, displayRules));
+
+            Hooks();
+        }
+
+        // Defining the item
+        private static void GenerateItem()
+        {
+            itemDef = ScriptableObject.CreateInstance<ItemDef>();
+
+            itemId = itemId.Replace(" ", "").ToUpper(); // Validate that itemId is in all caps, no spaces.
+
+            itemDef.name = itemId;
+            itemDef.nameToken = itemId + "_NAME";
+            itemDef.pickupToken = itemId + "_PICKUP";
+            itemDef.descriptionToken = itemId + "_DESCRIPTION";
+            itemDef.loreToken = itemId + "_LORE";
+
+            itemDef.tier = ItemTier.Tier1; // TODO Replace with own tier. (Common) 
+
+            // TODO Load your assets
+            itemDef.pickupIconSprite = AssetUtil.LoadSprite(""); 
+            itemDef.pickupModelPrefab = AssetUtil.LoadModel("");
+
+            itemDef.canRemove = true; 
+            itemDef.hidden = false; 
+
+            itemDef.tags = new ItemTag[]
+            {
+                ItemTag.BrotherBlacklist, ItemTag.Utility // TODO Add item tags like ItemTag.____
+            };
+        }
+
+        // The game logic for the item's functionality goes in this method
+        public static void Hooks()
+        {
+            // TODO Write item functionality. Start with the trigger, then write the rest. See other item implementations for examples.
+        }
+
+
+
+        // String definitions / key lookup
+        private static void AddTokens()
+        {
+            // TODO Add the text as it appears in game.
+            LanguageAPI.Add(itemId + "", "Item Name");
+            LanguageAPI.Add(itemId + "_NAME", "Item Name");
+            LanguageAPI.Add(itemId + "_PICKUP", "Pickup Flavor Text / Basic Description");
+            LanguageAPI.Add(itemId + "_DESCRIPTION", "A Detailed Description of the Item's Mechanics.");
+
+            string lore = "Lore Text"; //TODO Write your lore text here to be shown in the logbook.
+            LanguageAPI.Add(itemId + "_LORE", lore);
+        }
+    
+    }
+}

--- a/PrestigeItems/Items/DevCube.cs
+++ b/PrestigeItems/Items/DevCube.cs
@@ -37,29 +37,9 @@ namespace PrestigeItems.Items
 
             itemDef.tier = ItemTier.Tier1; // Common
 
-            try
-            {
-                Log.Debug($"Loading DevCube sprite...");
-                itemDef.pickupIconSprite = AssetUtil.bundle.LoadAsset<Sprite>("DevCube.png");
-                Log.Debug($"DevCube sprite loaded!");
-            }
-            catch (Exception e)
-            {
-                Log.Error(e.StackTrace);
-            }
+            itemDef.pickupIconSprite = AssetUtil.LoadSprite("DevCube.png");
+            itemDef.pickupModelPrefab = AssetUtil.LoadModel("DevCube.prefab");
 
-            try { 
-            Log.Debug($"Loading DevCube model...");
-                itemDef.pickupModelPrefab = AssetUtil.bundle.LoadAsset<GameObject>("DevCube.prefab");
-                Log.Debug($"DevCube model loaded!");
-            }
-            catch (Exception e)
-            {
-                Log.Error(e.StackTrace);
-            }
-
-            //itemDef.pickupIconSprite = Addressables.LoadAssetAsync<Sprite>("RoR2/Base/Common/MiscIcons/texMysteryIcon.png").WaitForCompletion();
-            //itemDef.pickupModelPrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Mystery/PickupMystery.prefab").WaitForCompletion();
             itemDef.canRemove = true;
             itemDef.hidden = false;
 

--- a/PrestigeItems/PrestigeItems.cs
+++ b/PrestigeItems/PrestigeItems.cs
@@ -43,12 +43,13 @@ namespace PrestigeItems
 
             // Initialize item classes
             DevCube.Init();
-            Boilerplate.Init(); // Disabled for now
+            //Boilerplate.Init(); // Disabled for now
         }
 
         // The Update() method is run on every frame of the game.
         private void Update()
         {
+            /* // These are debug controls. I'm disabling them during gameplay.
             // This if statement checks if the player has currently pressed F2.
             if (Input.GetKeyDown(KeyCode.F2))
             {
@@ -68,9 +69,10 @@ namespace PrestigeItems
 
                 // And then drop our defined item in front of the player.
 
-                Log.Info($"Player pressed F2. Spawning our custom item 2 at coordinates {transform.position}");
+                Log.Info($"Player pressed F3. Spawning our custom item 2 at coordinates {transform.position}");
                 PickupDropletController.CreatePickupDroplet(PickupCatalog.FindPickupIndex(Boilerplate.myItemDef.itemIndex), transform.position, transform.forward * 20f);
             }
+            */
         }
     }
 }

--- a/PrestigeItems/Util/AssetUtil.cs
+++ b/PrestigeItems/Util/AssetUtil.cs
@@ -1,5 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
 
 namespace PrestigeItems.Util
 {
@@ -7,6 +9,9 @@ namespace PrestigeItems.Util
     {
         public static AssetBundle bundle;
         public const string bundleName = "prestigemodassets";
+
+        public static Sprite defaultSprite = Addressables.LoadAssetAsync<Sprite>("RoR2/Base/Common/MiscIcons/texMysteryIcon.png").WaitForCompletion();
+        public static GameObject defaultModel = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Mystery/PickupMystery.prefab").WaitForCompletion();
 
         public static string AssetBundlePath
         {
@@ -20,5 +25,81 @@ namespace PrestigeItems.Util
         {
             bundle = AssetBundle.LoadFromFile(AssetBundlePath);
         }
+
+        /// <summary>
+        /// Loads the requested asset from the AssetBundle defined in AssetUtil. If the given filename is invalid, it falls back to the game's default Mystery icon.
+        /// </summary>
+        /// <param name="fileName">The filename of the asset as it appears in the AssetBundle. You must include the file extenstion.</param>
+        /// <returns>The loaded asset, if it exists within the AssetBundle. Otherwise, returns null.</returns>
+        private static T SafeLoad<T>(string fileName) where T : UnityEngine.Object
+        {
+            try
+            {
+                //Log.Debug($"Loading Template asset...");
+                var loaded = AssetUtil.bundle.LoadAsset<T>(fileName);
+
+                if (loaded == null)
+                {
+                    Log.Debug($"Asset {fileName} not found in the AssetBundle. Using fallback asset.");
+                }
+                return loaded;
+                //Log.Debug($"Template asset loaded!");
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Error loading asset {fileName}: {e.Message}\n{e.StackTrace}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Loads the requested Sprite from the AssetBundle.
+        /// </summary>
+        /// <param name="filename">The filename of the asset as it appears in the AssetBundle.</param>
+        /// <returns>The loaded Sprite, if it exists within the AssetBundle. Otherwise, returns the game's default Mystery icon.</returns>
+        public static Sprite LoadSprite(string filename)
+        {
+            if (!filename.Contains("."))
+            {
+                filename += ".png"; // Default handling if sent with no extension.
+            }
+            return SafeLoad<Sprite>(filename) ?? defaultSprite;
+        }
+
+        /// <summary>
+        /// Loads the requested GameObject (3D model) from the AssetBundle.
+        /// </summary>
+        /// <param name="filename">The filename of the asset as it appears in the AssetBundle.</param>
+        /// <returns>The loaded GameObject, if it exists within the AssetBundle. Otherwise, returns the game's default Mystery icon.</returns>
+        public static GameObject LoadModel(string filename)
+        {
+            if (!filename.Contains("."))
+            {
+                filename += ".prefab"; // Default handling if sent with no extension.
+            }
+            return SafeLoad<GameObject>(filename) ?? defaultModel;
+        }
+
+        /// <summary>
+        /// Loads a Sprite from the base game Risk of Rain 2 libraries. You must have the full path for the sprite.
+        /// </summary>
+        /// <param name="path">The path to the sprite in the game's files. Ex. "RoR2/Base/Common/MiscIcons/texMysteryIcon.png"</param>
+        /// <returns>The loaded Sprite from the game.</returns>
+        public static Sprite LoadBaseGameSprite(string path)
+        {
+            return Addressables.LoadAssetAsync<Sprite>(path).WaitForCompletion();
+        //public static GameObject defaultModel = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Mystery/PickupMystery.prefab").WaitForCompletion();
+        }
+
+        /// <summary>
+        /// Loads a GameObject (3D Model) from the base game Risk of Rain 2 libraries. You must have the full path for the sprite.
+        /// </summary>
+        /// <param name="path">The path to the model in the game's files. Ex. "RoR2/Base/Mystery/PickupMystery.prefab"</param>
+        /// <returns>The loaded GameObject from the game.</returns>
+        public static GameObject LoadBaseGameModel(string path)
+        {
+            return Addressables.LoadAssetAsync<GameObject>(path).WaitForCompletion();
+        }
     }
+
 }


### PR DESCRIPTION
Adds an item template I can base the rest of the item code off of as a starting point. Adds wrappers for loading objects from the assetbundle to the AssetUtil class to keep things simple and readable.